### PR TITLE
metainfo: Add device support metadata

### DIFF
--- a/flatpak/ch.bailu.gtk_meteo.metainfo.xml
+++ b/flatpak/ch.bailu.gtk_meteo.metainfo.xml
@@ -33,4 +33,12 @@
         <release version="0.2.0" date="2022-12-03"/>
         <release version="0.1.0" date="2022-08-05"/>
     </releases>
+    <recommends>
+        <control>keyboard</control>
+        <control>pointing</control>
+        <control>touch</control>
+    </recommends>
+    <requires>
+        <display_length compare="ge">360</display_length>
+    </requires>
 </component>


### PR DESCRIPTION
Thank you, @bailuk,, for creating this very helpful app!

This PR will (after a subsequent release) make GTK Meteo show up in Flathub's Mobile Collection: https://flathub.org/en/apps/collection/mobile/1

See https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/\#desktop-and-mobile-apps for further information regarding the change.